### PR TITLE
Add `#[must_use]` on types that implement `Future`

### DIFF
--- a/os/src/exec.rs
+++ b/os/src/exec.rs
@@ -856,6 +856,7 @@ impl<T> TestResult for Option<T> {
 pin_project! {
     /// Internal future type used to implement `Notify::until`. This makes it
     /// much easier to recognize the future in a debugger.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct Until<'n, F> {
         cond: F,
         notify: &'n Notify,
@@ -882,6 +883,7 @@ impl<F, T> Future for Until<'_, F>
 pin_project! {
     /// Internal future type used to implement `Notify::until_racy`. This makes
     /// it much easier to recognize the future in a debugger.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct UntilRacy<'n, F> {
         cond: F,
         notify: &'n Notify,
@@ -990,6 +992,7 @@ pub fn yield_cpu() -> impl Future<Output = ()> {
     YieldCpu { polled: false }
 }
 
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 struct YieldCpu {
     polled: bool,
 }

--- a/os/src/util.rs
+++ b/os/src/util.rs
@@ -63,6 +63,7 @@ pub trait FutureExt {
 impl<F: Future> FutureExt for F {}
 
 /// Future wrapper that adds a cancel action (result of [`FutureExt::on_cancel`]).
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 pub struct OnCancel<F, A>
     where A: FnOnce(),


### PR DESCRIPTION
Makes rustc emit a warning for mistakes like #12.

Forgetting to `.await` an `Until` can work surprisingly well...at least until the FIFO fills.