### PR TITLE
Update pin-project to stop Clippy warnings in output.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,18 +395,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ cfg-if = "1.0.0"
 cortex-m = {version = "0.7.4", features = ["inline-asm"]}
 cortex-m-rt = {version = "0.7.1"}
 cortex-m-semihosting = "0.5.0"
-pin-project = "1.1.5"
+pin-project = "1.1.6"
 panic-halt = "0.2.0"
 panic-semihosting = "0.6.0"
 futures = { version = "0.3.21", default-features = false, features = ["async-await"] }


### PR DESCRIPTION
I'm not convinced that the nightly-clippy build is adding value, mostly it's just causing me to notice churn in dependencies? We'll see. Anyway, this fixes it again.