### PR TITLE
RFC: Add `idle` parameter to idle callback

### DIFF
--- a/examples/stm32f4/uart-echo/src/main.rs
+++ b/examples/stm32f4/uart-echo/src/main.rs
@@ -96,7 +96,7 @@ fn main() -> ! {
     lilos::exec::run_tasks_with_idle(
         &mut [heartbeat, echo],
         lilos::exec::ALL_TASKS,
-        || {
+        |idle| if idle {
             device::GPIOD.bsrr().write(|w| w.set_br(15, true));
             cortex_m::asm::wfi();
             device::GPIOD.bsrr().write(|w| w.set_bs(15, true));


### PR DESCRIPTION
I'm not sure if this is a generally useful change, but I'm putting it up to have a conversation.

I've been using this with lilos in a user-mode like environment, where events are presented via an epollish-like syscall which I can call in the idle callback to poll for (and optionally wait for) events and then notify tasks. Without this change, and the `idle` flag, I get event starvation if there are runnable tasks for a long period of time (up to and including forever). Alternatively I could have an always runnable task to do polling but then it wouldn't ever be able to sleep (esp if I *also* want to support interrupt-driven events).

---
This changes the semantics of the idle callback to be called even if there are still runnable tasks. This allows it to be used to also poll for events rather than being entirely interrupt driven.

It now takes an `idle` bool parameter which tells the callback whether there are any active tasks. Using a body of the form

```
|idle| if idle { ... }
```
has the same semantics as before.